### PR TITLE
Added parse_mode option

### DIFF
--- a/sendtelegram.sh
+++ b/sendtelegram.sh
@@ -3,17 +3,18 @@
 function usage
 {
     if [ -n "$1" ]; then echo $1; fi
-    echo "Usage: sendtelegram [-v] [-c configfile] [-t token] [-i chatid] [-m message]"
+    echo "Usage: sendtelegram [-v] [-c configfile] [-t token] [-i chatid] [-p parse mode] [-m message]"
     exit 1
 }
 
 VERBOSE=0
 
-while getopts ":c:t:i:m:v" opt; do
+while getopts ":c:t:i:p:m:v" opt; do
     case "$opt" in
         c) CONFIGFILE=$OPTARG ;;
         t) TOKEN_ARG=$OPTARG ;;
         i) CHATID_ARG=$OPTARG ;;
+        p) PARSEMODE_ARG=$OPTARG ;;
         m) TEXT=$OPTARG ;;
         v) VERBOSE=1 ;;
         *) echo "Unknown param: $opt"; usage ;;
@@ -37,18 +38,26 @@ if [ -n "$CHATID_ARG" ]; then CHATID=$CHATID_ARG; fi
 if [ -z "$TOKEN" ]; then usage "Bot token not set, it must be provided in the config file, or on the command line."; fi;
 if [ -z "$CHATID" ]; then usage "Chat ID not set, it must be provided in the config file, or on the command line."; fi;
 if [ -z "$TEXT" ]; then usage "Message not set, it must be provided on the command line."; fi;
+if [ ! -z $PARSEMODE_ARG ] && [[ "$PARSEMODE_ARG" != +(markdown|html) ]]; then usage "Parse mode must be either 'markdown' or 'html'."; fi;
 
 # Sending to Telegram
 URL="https://api.telegram.org/bot$TOKEN/sendMessage"
 TIMEOUT=10
 
-echo "Sending message '$TEXT' to $CHATID"
+echo "Sending message '$TEXT' to $CHATID with CMDARGS $CMDARGS"
 
-CMD=`curl -s --max-time $TIMEOUT -d "chat_id=$CHATID&disable_web_page_preview=1&text=$TEXT" $URL 2>&1`
+CMDARGS="chat_id=$CHATID&disable_web_page_preview=1&text=$TEXT"
+
+if [ ! -z $PARSEMODE_ARG ]; then
+    CMDARGS=${CMDARGS}"&parse_mode=$PARSEMODE_ARG"
+fi
+
+CMD=`curl -s --max-time $TIMEOUT -d "$CMDARGS" $URL 2>&1`
 
 if [ $? -gt 0 ]; then echo "Failed sending Telegram"
 else echo "Done!"
 fi
 
 if [ "$VERBOSE" -eq 1 ]; then echo $CMD; fi
+
 

--- a/sendtelegram.sh
+++ b/sendtelegram.sh
@@ -44,7 +44,7 @@ if [ ! -z $PARSEMODE_ARG ] && [[ "$PARSEMODE_ARG" != +(markdown|html) ]]; then u
 URL="https://api.telegram.org/bot$TOKEN/sendMessage"
 TIMEOUT=10
 
-echo "Sending message '$TEXT' to $CHATID with CMDARGS $CMDARGS"
+echo "Sending message '$TEXT' to $CHATID"
 
 CMDARGS="chat_id=$CHATID&disable_web_page_preview=1&text=$TEXT"
 


### PR DESCRIPTION
Hi. 

I've added the parse_mode options according to the API docs (https://core.telegram.org/bots/api#sendmessage). Your script was very useful to me but I needed to send messages in Markdown format. I think this could be very useful when sending command outputs with Monit's exec command.

Thanks